### PR TITLE
make certbot version configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,3 +5,5 @@ letsencrypt_email: yourmail@example.com
 letsencrypt_domain: example.com
 # Always request www. also?
 letsencrypt_request_www: true
+# Version/Release tag or branch name of certbot to use
+letsencrypt_certbot_version: master

--- a/tasks/client.yaml
+++ b/tasks/client.yaml
@@ -16,4 +16,10 @@
 - name: Python cryptography module
   pip: name=cryptography
 - name: Letsencrypt Python client
-  git: dest=/opt/certbot clone=yes repo=https://github.com/certbot/certbot force=yes
+  git:
+    dest: /opt/certbot
+    clone: yes
+    update: yes
+    repo: https://github.com/certbot/certbot
+    force: yes
+    version: '{{letsencrypt_certbot_version}}'


### PR DESCRIPTION
It can be necessary to use a specific release/version/branch of certbot. This option allows to override the default `master` with a specific version (e.g. `v0.7.0`).
