### PR TITLE
fix error when skipping certificate renewal

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ letsencrypt_domain: example.com
 letsencrypt_request_www: true
 # Version/Release tag or branch name of certbot to use
 letsencrypt_certbot_version: master
+# Print Certbot output
+letsencrypt_certbot_verbose: true
 # Pause these services while updating the certificate
 letsencrypt_pause_services:
   - apache2

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -3,6 +3,9 @@
 - set_fact: letsencrypt_certbot_args="{{letsencrypt_certbot_args + ['--renew-by-default']}}"
   when: letsencrypt_force_renew == true
 
+- set_fact: letsencrypt_certbot_args="{{letsencrypt_certbot_args + ['--keep-until-expiring']}}"
+  when: letsencrypt_force_renew != true
+
 - set_fact: letsencrypt_domain="{{letsencrypt_domain}},www.{{letsencrypt_domain}}"
   when: letsencrypt_request_www
 

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -25,7 +25,7 @@
 - set_fact: _signing_skipped='{{ (letsencrypt_force_renew != true) and (certbot_skip_renewal_message in _certbot_command.stdout) }}'
 
 - debug: msg="{{ (_certbot_command.stdout_lines if _certbot_command.stdout_lines is defined else _certbot_command.stderr_lines) | pprint }}"
-  when: (_signing_successful == false) and (_signing_skipped == false)
+  when: letsencrypt_certbot_verbose or ((_signing_successful == false) and (_signing_skipped == false))
 
 - name: Starting Services
   service: name="{{item}}" state=started

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -1,12 +1,12 @@
 ---
 
-- set_fact: letsencrypt_certbot_args="{{letsencrypt_certbot_args + ['--renew-by-default']}}"
+- set_fact: _letsencrypt_certbot_args="{{letsencrypt_certbot_args + ['--renew-by-default']}}"
   when: letsencrypt_force_renew == true
 
-- set_fact: letsencrypt_certbot_args="{{letsencrypt_certbot_args + ['--keep-until-expiring']}}"
+- set_fact: _letsencrypt_certbot_args="{{letsencrypt_certbot_args + ['--keep-until-expiring']}}"
   when: letsencrypt_force_renew != true
 
-- set_fact: letsencrypt_domain="{{letsencrypt_domain}},www.{{letsencrypt_domain}}"
+- set_fact: _letsencrypt_domains="{{letsencrypt_domain}},www.{{letsencrypt_domain}}"
   when: letsencrypt_request_www
 
 - name: Stopping Services
@@ -14,7 +14,7 @@
   with_items: "{{ letsencrypt_pause_services }}"
 
 - name: Obtain or renew cert for domain
-  shell: ./certbot-auto certonly -t -m {{ letsencrypt_email }} --domains {{ letsencrypt_domain }} --agree-tos --standalone --expand {{letsencrypt_certbot_args | join(' ')}} 2>&1
+  shell: ./certbot-auto certonly -t -m {{ letsencrypt_email }} --domains {{ _letsencrypt_domains | default(letsencrypt_domain) }} --agree-tos --standalone --expand {{_letsencrypt_certbot_args | join(' ')}} 2>&1
   args:
     chdir: /opt/certbot
     executable: /bin/bash

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -14,16 +14,22 @@
   with_items: "{{ letsencrypt_pause_services }}"
 
 - name: Obtain or renew cert for domain
-  shell: ./certbot-auto certonly -m {{ letsencrypt_email }} --domains {{ letsencrypt_domain }} --agree-tos --standalone --expand {{letsencrypt_certbot_args | join(' ')}}
+  shell: ./certbot-auto certonly -t -m {{ letsencrypt_email }} --domains {{ letsencrypt_domain }} --agree-tos --standalone --expand {{letsencrypt_certbot_args | join(' ')}} 2>&1
   args:
     chdir: /opt/certbot
     executable: /bin/bash
   ignore_errors: true
-  register: certbot_command
+  register: _certbot_command
 
-- fail: msg="{{certbot_command.stderr}}"
-  when: (certbot_command.failed == true) and (certbot_command.stderr != 'User chose to cancel the operation and may reinvoke the client.')
+- set_fact: _signing_successful='{{ certbot_success_message in _certbot_command.stdout }}'
+- set_fact: _signing_skipped='{{ (letsencrypt_force_renew != true) and (certbot_skip_renewal_message in _certbot_command.stdout) }}'
+
+- debug: msg="{{ (_certbot_command.stdout_lines if _certbot_command.stdout_lines is defined else _certbot_command.stderr_lines) | pprint }}"
+  when: (_signing_successful == false) and (_signing_skipped == false)
 
 - name: Starting Services
   service: name="{{item}}" state=started
   with_items: "{{ letsencrypt_pause_services }}"
+
+- fail: msg="Error signing the certificate"
+  when: (_signing_successful == false) and (_signing_skipped == false)

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -14,7 +14,7 @@
   with_items: "{{ letsencrypt_pause_services }}"
 
 - name: Obtain or renew cert for domain
-  shell: ./certbot-auto certonly -t -m {{ letsencrypt_email }} --domains {{ _letsencrypt_domains | default(letsencrypt_domain) }} --agree-tos --standalone --expand {{_letsencrypt_certbot_args | join(' ')}} 2>&1
+  shell: ./certbot-auto certonly --text -m {{ letsencrypt_email }} --domains {{ _letsencrypt_domains | default(letsencrypt_domain) }} --agree-tos --standalone --expand {{_letsencrypt_certbot_args | join(' ')}} 2>&1
   args:
     chdir: /opt/certbot
     executable: /bin/bash

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -15,6 +15,11 @@
   args:
     chdir: /opt/certbot
     executable: /bin/bash
+  ignore_errors: true
+  register: certbot_command
+
+- fail: msg="{{certbot_command.stderr}}"
+  when: (certbot_command.failed == true) and (certbot_command.stderr != 'User chose to cancel the operation and may reinvoke the client.')
 
 - name: Starting Services
   service: name="{{item}}" state=started

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,5 @@
 ---
 # vars file for letsencrypt
+
+certbot_skip_renewal_message: "Certificate not yet due for renewal; no action taken"
+certbot_success_message: "Congratulations!"


### PR DESCRIPTION
**Update**: Reads certbot stdout to verify certificate creation and handle errors 
## 

Certbot exists with status code `1` when skipping a certificate renewal. 
(When option `letsencrypt_force_renew = false`)

```
"certbot_command": {
    "changed": true, 
    "cmd": "./certbot-auto certonly -m postmaster@example.org --domains example.org --agree-tos --standalone --expand ", 
    "delta": "0:00:00.868181", 
    "end": "2016-09-05 00:13:50.812381", 
    "failed": true, 
    "rc": 1, 
    "start": "2016-09-05 00:13:49.944200", 
    "stderr": "User chose to cancel the operation and may reinvoke the client.", 
    "stdout": "", 
    "stdout_lines": [], 
    "warnings": []
}
```

Now the certbot exit code is ignored if the message in stderr matches exactly

> "User chose to cancel the operation and may reinvoke the client."
