### PR TITLE
Do not install apache2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Stability: beta.
 This role will pull in the official [Certbot client](https://github.com/certbot/certbot), install it and issue or renew a certificate with your chosen domain.
 
 Currently the role is of limited functionality as follows:
-* Tested on Ubuntu 14.04
-* Using Apache2 to do validation
+* Tested on Ubuntu 14.04 and Debian 8
 * One domain per role include only
 * No automatic installation, certonly mode only
 
@@ -23,7 +22,7 @@ PR's are welcome to include more functionality.
 
 * The client will be installed in `/opt/certbot` as root
 * Each run will pull in the latest Certbot client code. You can set a specific Certbot version using the variable `letsencrypt_certbot_version`.
-* The role will by default stop Apache2 before requesting a cert and then restart it after done. The list of services to be stopped and started can be configured using the variable `letsencrypt_pause_services`.
+* A list of services to be stopped before and (re-)started after obtaining a new certificate can be configured using the variable `letsencrypt_pause_services`.
 * `certonly` mode is used, which means no automatic web server installation
 * After cert issuing, you can find it in `/etc/letsencrypt/live/<domainname>`
    * Tip, use this in your Apache2 config, for example, in your main role. Just make sure not to try and start Apache2 with the virtualhost active without the LetsEncrypt role running first!
@@ -43,8 +42,8 @@ PR's are welcome to include more functionality.
 
 Tested with the following:
 
-* Ubuntu 14.04
-* Apache2
+* Ubuntu 14.04 and Debian 8
+* Apache2 and Nginx
 * Ansible 1.9 / 2.x
 
 ### Role Variables
@@ -59,7 +58,7 @@ Tested with the following:
 * `letsencrypt_certbot_args` - Additional command line args to Certbot.
 * `letsencrypt_certbot_version` - Set specific Certbot version, for example a git tag or branch. Note that the lowest version of Certbot we support is 0.6.0.
 * `letsencrypt_force_renew` - Whether to attempt renewal always, default to `true`.
-* `letsencrypt_pause_services` - List of services to stop/start while calling Certbot. Defaults to `apache2`.
+* `letsencrypt_pause_services` - List of services to stop/start while calling Certbot.
 * `letsencrypt_request_www` - Request `www.` automatically (default `true`).
 
 ### Example Playbook
@@ -73,7 +72,11 @@ This role should become root on the target host.
       become: yes
       become_user: root
       roles:
-        - { role: ansible-letsencrypt, letsencrypt_email: email@example.com, letsencrypt_domain: example.com }
+        - role: ansible-letsencrypt
+          letsencrypt_email: email@example.com
+          letsencrypt_domain: example.com
+          letsencrypt_pause_services:
+            - apache2
 
 ### License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,7 @@ letsencrypt_certbot_version: master
 # Print Certbot output
 letsencrypt_certbot_verbose: true
 # Pause these services while updating the certificate
-letsencrypt_pause_services:
-  - apache2
+letsencrypt_pause_services: []
 # Force Certificate Reneval
 letsencrypt_force_renew: true
 # Additional certbot arguments

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -13,6 +13,7 @@
   service: name="{{item}}" state=stopped
   with_items: "{{ letsencrypt_pause_services }}"
   ignore_errors: yes
+  register: _services_stopped
 
 - name: Obtain or renew cert for domain
   shell: ./certbot-auto certonly --text -n -m {{ letsencrypt_email }} --domains {{ _letsencrypt_domains | default(letsencrypt_domain) }} --agree-tos --standalone --expand {{_letsencrypt_certbot_args | join(' ')}} 2>&1
@@ -28,9 +29,10 @@
 - debug: msg="{{ (_certbot_command.stdout_lines if _certbot_command.stdout_lines is defined else _certbot_command.stderr_lines) | pprint }}"
   when: letsencrypt_certbot_verbose or ((_signing_successful == false) and (_signing_skipped == false))
 
-- name: Starting Services
-  service: name="{{item}}" state=started
-  with_items: "{{ letsencrypt_pause_services }}"
+- name: Starting paused Services
+  service: name="{{item.item}}" state=started
+  when: (item.failed != true) and (item.state == "stopped")
+  with_items: "{{ _services_stopped.results }}"
 
 - fail: msg="Error signing the certificate"
   when: (_signing_successful == false) and (_signing_skipped == false)

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -12,6 +12,7 @@
 - name: Stopping Services
   service: name="{{item}}" state=stopped
   with_items: "{{ letsencrypt_pause_services }}"
+  ignore_errors: yes
 
 - name: Obtain or renew cert for domain
   shell: ./certbot-auto certonly --text -n -m {{ letsencrypt_email }} --domains {{ _letsencrypt_domains | default(letsencrypt_domain) }} --agree-tos --standalone --expand {{_letsencrypt_certbot_args | join(' ')}} 2>&1

--- a/tasks/client.yaml
+++ b/tasks/client.yaml
@@ -12,7 +12,6 @@
     - dialog
     - libaugeas0
     - ca-certificates
-    - apache2
 - name: Python cryptography module
   pip: name=cryptography
 - name: Letsencrypt Python client


### PR DESCRIPTION
Installing apache2 as dependency was legacy before merging #4 - without apache2 being is installed this role would fail with it's default configuration, but the `ignore_errors: yes` option allows us to just skip about that.
