### PR TITLE
Run certbot with non-interactive flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### Changed
+* Certbot now runs with the `--non-interactive` flag, which should protect from Ansible hanging on unexpected prompts. **Note! This flag was added in Certbot 0.6.0** which is the lowest version this role can thus support.
+
 ## [0.4.1] - 2016-09-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Tested with the following:
 #### Optional
 
 * `letsencrypt_certbot_args` - Additional command line args to Certbot.
-* `letsencrypt_certbot_version` - Set specific Certbot version, for example a git tag or branch.
+* `letsencrypt_certbot_version` - Set specific Certbot version, for example a git tag or branch. Note that the lowest version of Certbot we support is 0.6.0.
 * `letsencrypt_force_renew` - Whether to attempt renewal always, default to `true`.
 * `letsencrypt_pause_services` - List of services to stop/start while calling Certbot. Defaults to `apache2`.
 * `letsencrypt_request_www` - Request `www.` automatically (default `true`).

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -14,7 +14,7 @@
   with_items: "{{ letsencrypt_pause_services }}"
 
 - name: Obtain or renew cert for domain
-  shell: ./certbot-auto certonly --text -m {{ letsencrypt_email }} --domains {{ _letsencrypt_domains | default(letsencrypt_domain) }} --agree-tos --standalone --expand {{_letsencrypt_certbot_args | join(' ')}} 2>&1
+  shell: ./certbot-auto certonly --text -n -m {{ letsencrypt_email }} --domains {{ _letsencrypt_domains | default(letsencrypt_domain) }} --agree-tos --standalone --expand {{_letsencrypt_certbot_args | join(' ')}} 2>&1
   args:
     chdir: /opt/certbot
     executable: /bin/bash


### PR DESCRIPTION
Not sure when this arrived in Certbot (since it doesn't have a changelog), but it's there now so we should probably run with it to avoid Ansible hanging on unexpected prompts.
