### PR TITLE
limit certbot clone depth to 1

### DIFF
--- a/tasks/client.yaml
+++ b/tasks/client.yaml
@@ -20,6 +20,7 @@
     dest: /opt/certbot
     clone: yes
     update: yes
+    depth: 1
     repo: https://github.com/certbot/certbot
     force: yes
     version: '{{letsencrypt_certbot_version}}'


### PR DESCRIPTION
Only clone latest commit of certbot. Speeds up installing and updating the certbot client.
