### PR TITLE
Make default Certbot version a stable release, not dev branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Changed
 * Certbot now runs with the `--non-interactive` flag, which should protect from Ansible hanging on unexpected prompts. **Note! This flag was added in Certbot 0.6.0** which is the lowest version this role can thus support.
+* Default version of Certbot installed is now v0.8.1, the latest release as of now. Master branch can have unexpected breakages. Due to this, the cli flag `--no-self-upgrade` was also added to stop Certbot from automatically updating itself.
 
 ## [0.4.1] - 2016-09-04
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,17 @@ Stability: beta.
 
 This role will pull in the official [Certbot client](https://github.com/certbot/certbot), install it and issue or renew a certificate with your chosen domain.
 
-Currently the role is of limited functionality as follows:
+Functionality as follows:
 * Tested on Ubuntu 14.04 and Debian 8
 * One domain per role include only
-* No automatic installation, certonly mode only
+* Runs in `certonly` mode only
 
 PR's are welcome to include more functionality.
 
 #### More detail
 
 * The client will be installed in `/opt/certbot` as root
-* Each run will pull in the latest Certbot client code. You can set a specific Certbot version using the variable `letsencrypt_certbot_version`.
+* Each run will pull in the Certbot client code from a proven release version. You can set a specific Certbot version using the variable `letsencrypt_certbot_version`.
 * A list of services to be stopped before and (re-)started after obtaining a new certificate can be configured using the variable `letsencrypt_pause_services`.
 * `certonly` mode is used, which means no automatic web server installation
 * After cert issuing, you can find it in `/etc/letsencrypt/live/<domainname>`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ letsencrypt_domain: example.com
 # Always request www. also?
 letsencrypt_request_www: true
 # Version/Release tag or branch name of certbot to use
-letsencrypt_certbot_version: master
+letsencrypt_certbot_version: v0.8.1
 # Print Certbot output
 letsencrypt_certbot_verbose: true
 # Pause these services while updating the certificate

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -16,7 +16,7 @@
   register: _services_stopped
 
 - name: Obtain or renew cert for domain
-  shell: ./certbot-auto certonly --text -n -m {{ letsencrypt_email }} --domains {{ _letsencrypt_domains | default(letsencrypt_domain) }} --agree-tos --standalone --expand {{_letsencrypt_certbot_args | join(' ')}} 2>&1
+  shell: ./certbot-auto certonly --text -n --no-self-upgrade -m {{ letsencrypt_email }} --domains {{ _letsencrypt_domains | default(letsencrypt_domain) }} --agree-tos --standalone --expand {{_letsencrypt_certbot_args | join(' ')}} 2>&1
   args:
     chdir: /opt/certbot
     executable: /bin/bash


### PR DESCRIPTION
Also, don't automatically update Certbot since we lock to version.
