### PR TITLE
Fix starting paused services

### DIFF
--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -31,7 +31,7 @@
 
 - name: Starting paused Services
   service: name="{{item.item}}" state=started
-  when: (item.failed != true) and (item.state == "stopped")
+  when: (item.state is defined and item.state == "stopped")
   with_items: "{{ _services_stopped.results }}"
 
 - fail: msg="Error signing the certificate"


### PR DESCRIPTION
The stopped services result dict had no failed dict key for successfully stopped services. Always start services which are stopped.

The dict looks like this:

```
"_services_stopped": {
    "changed": true, 
    "msg": "All items completed", 
    "results": [
        {
            "_ansible_item_result": true, 
            "_ansible_no_log": false, 
            "changed": true, 
            "invocation": {
                "module_args": {
                    "arguments": "", 
                    "enabled": null, 
                    "name": "apache2", 
                    "pattern": null, 
                    "runlevel": "default", 
                    "sleep": null, 
                    "state": "stopped"
                }, 
                "module_name": "service"
            }, 
            "item": "apache2", 
            "name": "apache2", 
            "state": "stopped"
        }
    ]
}
```

Added a debug to print this out, could be useful sometimes if things fail to see what was stopped.
