### PR TITLE
Add tests and Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+---
+services: docker
+
+env:
+# ubuntu1604 fails due to apt error: No package matching 'build-essential' is available
+#  - distro: ubuntu1604
+#    init: /lib/systemd/systemd
+#    run_opts: "--privileged --volume=/sys/fs/cgroup:/sys/fs/cgroup:ro"
+  - distro: ubuntu1404
+    init: /sbin/init
+    run_opts: ""
+# TODO: add debian
+
+before_install:
+  # Pull container.
+  - 'docker pull geerlingguy/docker-${distro}-ansible:latest'
+
+script:
+  - container_id=$(mktemp)
+  # Run container in detached state.
+  - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:rw ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
+
+  # Ansible syntax check.
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
+
+  # Test role.
+  - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
+
+  # Test role idempotence.
+  - idempotence=$(mktemp)
+  - docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml | tee -a ${idempotence}
+  - >
+    tail ${idempotence}
+    | grep -q 'changed=0.*failed=0'
+    && (echo 'Idempotence test: pass' && exit 0)
+    || (echo 'Idempotence test: fail' && exit 1)
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,3 +26,7 @@ letsencrypt_certbot_default_args:
   - --domains '{{ _letsencrypt_domains | default(letsencrypt_domain) }}'
   - -m '{{letsencrypt_email}}'
   - --agree-tos
+
+
+# This is enabled when running tests - DO NOT TOUCH
+letsencrypt_test: false

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -20,15 +20,19 @@
     executable: /bin/bash
   ignore_errors: true
   register: _certbot_command
+  when: not letsencrypt_test
 
 - set_fact: _signing_successful='{{ certbot_success_message in _certbot_command.stdout }}'
+  when: not letsencrypt_test
 - set_fact: _signing_skipped='{{ (certbot_skip_renewal_message in _certbot_command.stdout) and not letsencrypt_force_renew }}'
+  when: not letsencrypt_test
 - debug: msg="{{ (_certbot_command.stdout_lines if _certbot_command.stdout_lines is defined else _certbot_command.stderr_lines) | pprint }}"
-  when: letsencrypt_certbot_verbose or ((not _signing_successful) and not _signing_skipped)
+  when: not letsencrypt_test and (letsencrypt_certbot_verbose or ((not _signing_successful) and not _signing_skipped))
+
 - name: Starting paused Services
   service: name="{{item.item}}" state=started
   when: (item.state is defined and item.state == "stopped")
   with_items: "{{ _services_stopped.results|default([]) }}"
 
 - fail: msg="Error signing the certificate"
-  when: (not _signing_successful) and not _signing_skipped
+  when: not letsencrypt_test and not _signing_successful and not _signing_skipped

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,3 +1,6 @@
 ---
 - include: client.yaml
 - include: cert.yaml
+
+- include: test.yaml
+  when: letsencrypt_test

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -1,0 +1,18 @@
+---
+- debug: msg="{{ _letsencrypt_certbot_combined_args | pprint }}"
+
+- fail: msg="Expected args to certbot were not as expected"
+  when: letsencrypt_test_expected_args != _letsencrypt_certbot_combined_args
+
+# When testing, run certbot-auto with an invalid argument just to make it build the environment..
+- shell: ./certbot-auto --no-self-upgrade invalid-test-arg 2>&1
+  args:
+    chdir: /opt/certbot
+    executable: /bin/bash
+  ignore_errors: true
+  register: _certbot_test_command
+
+- set_fact: _certbot_test_successful='{{ certbot_test_success_message in _certbot_test_command.stdout }}'
+
+- fail: msg="Invalid test response from certbot-auto"
+  when: not _certbot_test_command

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,23 @@
+---
+- hosts: all
+
+  vars:
+    letsencrypt_email: user@example.com
+    letsencrypt_domain: example.com
+    letsencrypt_pause_services:
+      - apache2
+    letsencrypt_test: true
+    letsencrypt_test_expected_args:
+      - --renew-by-default
+      - certonly
+      - --standalone
+      - --expand
+      - --text
+      - -n
+      - --no-self-upgrade
+      - --domains 'example.com'
+      - -m 'user@example.com'
+      - --agree-tos
+
+  roles:
+    - role_under_test

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,3 +3,4 @@
 
 certbot_skip_renewal_message: "Certificate not yet due for renewal; no action taken"
 certbot_success_message: "Congratulations!"
+certbot_test_success_message: "letsencrypt: error: unrecognized arguments: invalid-test-arg"


### PR DESCRIPTION
Run the role in test mode in Travis using Docker images. Unfortunately since the LetsEncrypt server, even in staging mode, will always call back, so we can't actually execute that command. Instead we just make it install and check the arguments that we would use look correct.

Idea for test and Travis config mostly stolen from https://github.com/geerlingguy/ansible-role-apache