### PR TITLE
Fix regression relating to requesting www. domains

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,12 @@ script:
   # Ansible syntax check.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
 
+  # Fix pip - see https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1658844
+  - 'docker exec "$(cat ${container_id})" apt-get update'
+  - 'docker exec "$(cat ${container_id})" apt-get install -y python-pip'
+  - 'docker exec "$(cat ${container_id})" python -m pip install -U pip'
+  - 'docker exec "$(cat ${container_id})" pip install -U pip setuptools'
+
   # Test role.
   - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [unreleased]
+
+### Fixed
+* Fix regression relating to requesting `www.` domains introduced after 0.6.0. The regression caused a `www.` domain not to be requested even if explicitly setting `letsencrypt_request_www` to `true`. Note that this functionality used to work after the release of 0.6.0 AFAIK, but was possibly broken by a behaviour change in Ansible 2.1.
+
 ## [0.6.0] - 2016-11-19
 
 ### Important!

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,10 +23,8 @@ letsencrypt_certbot_default_args:
   - --text
   - -n
   - --no-self-upgrade
-  - --domains '{{ _letsencrypt_domains | default(letsencrypt_domain) }}'
   - -m '{{letsencrypt_email}}'
   - --agree-tos
-
 
 # This is enabled when running tests - DO NOT TOUCH
 letsencrypt_test: false

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -1,11 +1,17 @@
 ---
 - set_fact: _letsencrypt_certbot_args="{{ letsencrypt_certbot_args + ['--renew-by-default'] }}"
   when: letsencrypt_force_renew
+
 - set_fact: _letsencrypt_certbot_args="{{ letsencrypt_certbot_args + ['--keep-until-expiring'] }}"
   when: not letsencrypt_force_renew
-- set_fact: _letsencrypt_certbot_combined_args="{{_letsencrypt_certbot_args + letsencrypt_certbot_default_args + letsencrypt_certbot_args}}"
-- set_fact: _letsencrypt_domains="{{letsencrypt_domain}},www.{{letsencrypt_domain}}"
+
+- set_fact: _letsencrypt_domains="--domains {{letsencrypt_domain}},www.{{letsencrypt_domain}}"
   when: letsencrypt_request_www
+
+- set_fact: _letsencrypt_domains="--domains {{letsencrypt_domain}}"
+  when: not letsencrypt_request_www
+
+- set_fact: _letsencrypt_certbot_combined_args="{{_letsencrypt_certbot_args + letsencrypt_certbot_default_args + letsencrypt_certbot_args + [_letsencrypt_domains] }}"
 
 - name: Stopping Services
   service: name="{{item}}" state=stopped

--- a/tasks/test.yaml
+++ b/tasks/test.yaml
@@ -11,6 +11,7 @@
     executable: /bin/bash
   ignore_errors: true
   register: _certbot_test_command
+  changed_when: False
 
 - set_fact: _certbot_test_successful='{{ certbot_test_success_message in _certbot_test_command.stdout }}'
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -15,9 +15,9 @@
       - --text
       - -n
       - --no-self-upgrade
-      - --domains 'example.com'
       - -m 'user@example.com'
       - --agree-tos
+      - --domains example.com,www.example.com
 
   roles:
     - role_under_test


### PR DESCRIPTION
Regression happened after 0.6.0. The regression caused a `www.` domain not to be requested even if explicitly setting `letsencrypt_request_www` to `true`.

Note that this functionality used to work after the release of 0.6.0 AFAIK, but was possibly broken by a behaviour change in Ansible 2.1.