### PR TITLE
Avoid problems on Ubuntu by using a newer version of pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,8 @@ script:
   # Ansible syntax check.
   - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
 
-  # Fix pip - see https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1658844
-  - 'docker exec "$(cat ${container_id})" apt-get update'
-  - 'docker exec "$(cat ${container_id})" apt-get install -y python-pip'
-  - 'docker exec "$(cat ${container_id})" python -m pip install -U pip'
-  - 'docker exec "$(cat ${container_id})" pip install -U pip setuptools'
+  # Avoid pip bug https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1658844
+  - 'docker exec "$(cat ${container_id})" ansible-galaxy install tersmitten.pip'
 
   # Test role.
   - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ script:
   # Run container in detached state.
   - 'docker run --detach --volume="${PWD}":/etc/ansible/roles/role_under_test:rw ${run_opts} geerlingguy/docker-${distro}-ansible:latest "${init}" > "${container_id}"'
 
-  # Ansible syntax check.
-  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
-
   # Avoid pip bug https://bugs.launchpad.net/ubuntu/+source/python-pip/+bug/1658844
   - 'docker exec "$(cat ${container_id})" ansible-galaxy install tersmitten.pip'
+
+  # Ansible syntax check.
+  - 'docker exec --tty "$(cat ${container_id})" env TERM=xterm ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml --syntax-check'
 
   # Test role.
   - 'docker exec "$(cat ${container_id})" ansible-playbook /etc/ansible/roles/role_under_test/tests/test.yml'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,4 +16,5 @@ galaxy_info:
   - web
   galaxy_tags:
     - letsencrypt
-dependencies: []
+dependencies:
+  - tersmitten.pip

--- a/tasks/client.yaml
+++ b/tasks/client.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Operating system dependencies
-  apt: name={{ item }} state=present
+  apt: name={{ item }} state=present update_cache=yes
   with_items:
     - build-essential
     - libssl-dev

--- a/tasks/client.yaml
+++ b/tasks/client.yaml
@@ -7,7 +7,6 @@
     - libffi-dev
     - python-dev
     - git
-    - python-pip
     - python-virtualenv
     - dialog
     - libaugeas0


### PR DESCRIPTION
This role was failing for me on Ubuntu 14.04 due to errors when pip tried to install the cryptography module. Installing pip with easy_install instead of apt-get fixed the problem. Fortunately, there's a reliable role on Galaxy that does that. 