### PR TITLE
Add support for Debian 9 Stretch

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can install the role directly from Galaxy as follows:
 
 Tested with the following:
 
-* Ubuntu 14.04 and Debian 8
+* Ubuntu 14.04 and Debian 8, Debian 9
 * Apache2 and Nginx
 * Ansible 2.x
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Ansible version required: 2.x
 This role will pull in the official [Certbot client](https://github.com/certbot/certbot), install it and issue or renew a certificate with your chosen domain.
 
 Functionality as follows:
-* Tested on Ubuntu 14.04 and Debian 8
+* Tested on Ubuntu 14.04 and Debian 8, Debian 9
 * One domain per role include only
 * Runs in `certonly` mode only
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,6 +11,7 @@ galaxy_info:
   - name: Debian
     versions:
     - jessie
+    - stretch
   categories:
   - cloud
   - web

--- a/tasks/cert.yaml
+++ b/tasks/cert.yaml
@@ -1,4 +1,5 @@
 ---
+# prepare arguments
 - set_fact: _letsencrypt_certbot_args="{{ letsencrypt_certbot_args + ['--renew-by-default'] }}"
   when: letsencrypt_force_renew
 
@@ -13,21 +14,37 @@
 
 - set_fact: _letsencrypt_certbot_combined_args="{{_letsencrypt_certbot_args + letsencrypt_certbot_default_args + letsencrypt_certbot_args + [_letsencrypt_domains] }}"
 
+# stop service
 - name: Stopping Services
   service: name="{{item}}" state=stopped
   with_items: "{{ letsencrypt_pause_services }}"
   ignore_errors: yes
   register: _services_stopped
 
-- name: Obtain or renew cert for domain
+# do the actual work
+- name: Obtain or renew cert for domain (source client)
   shell: ./certbot-auto {{_letsencrypt_certbot_combined_args | join(' ')}} 2>&1
   args:
     chdir: /opt/certbot
     executable: /bin/bash
   ignore_errors: true
   register: _certbot_command
-  when: not letsencrypt_test
+  when:
+    - not letsencrypt_test
+    - not ansible_distribution_release == 'stretch'
 
+# do the actual work
+- name: Obtain or renew cert for domain (debian client)
+  shell: certbot {{_letsencrypt_certbot_combined_args | join(' ')}} 2>&1
+  args:
+    executable: /bin/bash
+  ignore_errors: true
+  register: _certbot_command
+  when:
+    - not letsencrypt_test
+    - ansible_distribution_release == 'stretch'
+
+# analyze output
 - set_fact: _signing_successful='{{ certbot_success_message in _certbot_command.stdout }}'
   when: not letsencrypt_test
 - set_fact: _signing_skipped='{{ (certbot_skip_renewal_message in _certbot_command.stdout) and not letsencrypt_force_renew }}'

--- a/tasks/client.yaml
+++ b/tasks/client.yaml
@@ -1,4 +1,5 @@
 ---
+# clone client from source
 - name: Operating system dependencies
   apt: name={{ item }} state=present
   with_items:
@@ -12,8 +13,10 @@
     - dialog
     - libaugeas0
     - ca-certificates
+  when: not ansible_distribution_release == 'stretch'
 - name: Python cryptography module
   pip: name=cryptography
+  when: not ansible_distribution_release == 'stretch'
 - name: Letsencrypt Python client
   git:
     dest: /opt/certbot
@@ -22,3 +25,11 @@
     repo: https://github.com/certbot/certbot
     force: yes
     version: '{{letsencrypt_certbot_version}}'
+  when: not ansible_distribution_release == 'stretch'
+
+# install client from package repo (available in debian stretch)
+- name: Install Certbot
+  apt: name={{ item }} update_cache=yes state=latest
+  with_items:
+    - certbot
+  when: ansible_distribution_release == 'stretch'


### PR DESCRIPTION
Cloning certbot from source seems to cause some issues in Debian 9, but as the certbot is already available in the default repo we can simply use it instead in this case.